### PR TITLE
Updated New-LoopAction

### DIFF
--- a/New-LoopAction.ps1
+++ b/New-LoopAction.ps1
@@ -108,6 +108,9 @@ function New-LoopAction {
                 $StopWatch = [System.Diagnostics.Stopwatch]::StartNew()
                 $FirstRunDone = $false        
             }
+            'ForLoop' {
+                $FirstRunDone = $false
+            }
         }
     }
     process {


### PR DESCRIPTION
Added `Write-Verbose` lines to help with troubleshooting

Also, I noticed the `-LoopDelayType` param was only for the `DoUntil` parameter set which made it unavailable if you were to use the `ForLoop` parameter set. I found this odd as it was referenced in the process block for the splat of `Start-Sleep`, so I assumed this was a mistake and included that adjustment here too.

Also, I can't explain this, but (for the ForLoop parameter set) I had to explicitly set `$FirstRunDone` to false in the begin block in order for the first run to skip the sleep. I found it always ran the Start-Sleep. 